### PR TITLE
refactor(unbox.js): Remove useless backlog push condition

### DIFF
--- a/unbox.js
+++ b/unbox.js
@@ -126,6 +126,13 @@ function createUnboxStream(opts) {
       increment(opts.nonce)
 
       this.push(unboxed)
+    } else {
+      const unboxed = unbox(chunk, opts)
+
+      increment(opts.nonce)
+      increment(opts.nonce)
+
+      this.push(unboxed)
     }
 
     done(null)


### PR DESCRIPTION
Fixes A bug in how chunks are pushed through the transform stream. The backlog should only contain header packets and should only be consumed when the backlog is not empty on the next write.

## Proposed Changes

  - Only push header packets to backlog before unboxing on next message